### PR TITLE
Migrate set-output to GITHUB_OUTPUT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ runs:
         GREET="Hello ${WHO}"
         echo "${GREET}"
         echo "${GREET}" > greet.txt
-        echo "::set-output name=word::${GREET}"
+        echo "word=${GREET}" >> $GITHUB_OUTPUT
       shell: bash
       env:
         WHO: ${{ inputs.who-to-greet }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/